### PR TITLE
Create release-reminder.yml

### DIFF
--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -1,0 +1,37 @@
+name: Release reminder
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * 2,4' # At 10:00 UTC every Tuesday and Thursday (https://crontab.guru/#0_10_*_*_2,4)
+
+jobs:
+  check_changes_since_last_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest release tag
+        run: |
+          echo "LATEST_RELEASE_TAG=$(gh release view --json tagName --template '{{.tagName}}')" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check diff between latest release and HEAD
+        run: |
+          git diff $LATEST_RELEASE_TAG..HEAD --stat --exit-code -- **/*.js package*.json Dockerfile ':^**/*.test.js' \
+          && echo "HAS_CHANGES_SINCE_LATEST_RELEASE=false" || echo "HAS_CHANGES_SINCE_LATEST_RELEASE=true" >> $GITHUB_ENV
+
+      - name: Send Slack notification if there are changes since the last release
+        if: env.HAS_CHANGES_SINCE_LATEST_RELEASE == 'true'
+        uses: slackapi/slack-github-action@v1.22
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: |
+            :wave: `${{ github.event.repository.name }}` has <${{ github.server_url }}/${{ github.repository }}/compare/${{ env.LATEST_RELEASE_TAG }}...HEAD|unreleased changes>. Please consider <${{ github.server_url }}/${{ github.repository }}/releases/new|deploying a new version>.
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Note that I've put the Slack channel id in a repository secret so that it's not visible to anyone with read access to the source code. I also changed the second link in the Slack message to point to the "Draft new release" page, since there is no bump-version workflow in this repo.