### PR TITLE
Keep Slack channel ID secret in npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Slack notification
         uses: slackapi/slack-github-action@v1.22
         with:
-          channel-id: '#donauts-launchpad-open'
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: |
             :package: Release published: <${{ github.event.release.html_url }}|*${{ github.repository }} ${{ github.ref_name }}*>
         env:


### PR DESCRIPTION
No need to disclose the Slack channel used for notifications in this repo.